### PR TITLE
Fix broken links reported by html-proofer

### DIFF
--- a/_alpha/1-introduction/index.md
+++ b/_alpha/1-introduction/index.md
@@ -28,4 +28,4 @@ It's also not just restricted to prototyping only ideas constrained by current b
 
 ![Don't skip alpha]({{ site.baseurl }}/images/alpha/shortcut.jpg)
 
-[Next section: The team]({{ site.baseurl }}/alpha/2-team)
+[Next section: The team]({{ site.baseurl }}/alpha/2-getting-started/2-1-the-team.html)

--- a/_alpha/3-building-prototypes/3-2-tools-technology.md
+++ b/_alpha/3-building-prototypes/3-2-tools-technology.md
@@ -37,4 +37,4 @@ As part of the user research, you should test your prototypes with users who hav
 
 
 
-[Next section: Supporting Activities](3-4-supporting-activities.html)
+[Next section: Supporting Activities]({{ site.baseurl }}/alpha/4-finishing-alpha/4-1-defining-mvp.html)

--- a/_discovery/2-starting-discovery/2-1-before-you-start.md
+++ b/_discovery/2-starting-discovery/2-1-before-you-start.md
@@ -7,7 +7,7 @@ Before starting a discovery, take some time to prepare so that you can make the 
 
 We’d recommend that you:
 
-- make sure there are [the right capabilities in the team](https://www.dto.gov.au/design-guides/guide/team), and that you’ve highlighted any gaps - see the roles list earlier in the document for more detailed information on this
+- make sure there are [the right capabilities in the team](https://www.dto.gov.au/standard/design-guides/the-team/), and that you’ve highlighted any gaps - see the roles list earlier in the document for more detailed information on this
 - know who your stakeholders and subject matter experts are, and schedule regular team time with them for the whole Discovery
 - select a user research recruitment agency, so that the user researchers can start researching with users in the first couple of weeks start preparing your recruitment briefs as soon as you have identified your user base, finding actual representative users can take some time. Aim to include a participant with a physical or cognitive challenge in this.
 - find a good, open space for the team to co-locate during Discovery - one with plenty of wall space and whiteboards - and bring lots of stationery: post-it notes, index cards and sharpie markers are a must

--- a/_discovery/2-starting-discovery/2-3-ways-of-working.md
+++ b/_discovery/2-starting-discovery/2-3-ways-of-working.md
@@ -7,7 +7,7 @@ The team will use Agile techniques and practices, ensuring collaboration, planni
 
 <iframe class="video" width="100%" height="315" src="https://www.youtube.com/embed/502ILHjX9EE" frameborder="0" allowfullscreen></iframe>
 
-<img src="{{ site.baseurl }}/images/discovery/2/agile-approach.png" class="full-width">
+<img src="{{ site.baseurl }}/images/discovery/2/agile-approach.png" class="full-width" alt="Overview of the agile approach">
 
 ## 2.3.1. Sprints
 

--- a/_discovery/3-finishing-discovery/3-2-reporting-findings.md
+++ b/_discovery/3-finishing-discovery/3-2-reporting-findings.md
@@ -8,7 +8,7 @@ At the end of discovery, you should report back on your findings in a discovery 
 Your discovery document should include:
 
 - an overview of the approach you took and who you engaged with
-- [the artefacts you've produced]({{ site.baseurl }}/2-starting-discovery/2-5-artefacts.html), including a service map
+- [the artefacts you've produced]({{ site.baseurl }}/discovery/2-starting-discovery/2-5-artefacts.html), including a service map
 - the major findings that emerged from user research and the technology discovery
 - recommendations and hypotheses you're going to test at alpha
 

--- a/_discovery/3-finishing-discovery/3-3-digital-service-standard.md
+++ b/_discovery/3-finishing-discovery/3-3-digital-service-standard.md
@@ -19,7 +19,8 @@ The team can meet this criteria by:
 - Articulating insights that identify design requirements; both digital and assisted digital
 - Explaining their user research approach, plan and findings.
 
-Design guides that will be helpful in meeting this criteria include: [affinity diagramming](https://www.dto.gov.au/design-guides/subguides/affinity-diagramming); [card sorting](https://www.dto.gov.au/design-guides/subguides/card-sorting); [ethnographic research](https://www.dto.gov.au/design-guides/subguides/ethnographic-research); [high level design](https://www.dto.gov.au/design-guides/subguides/high-level-design); [interviews](https://www.dto.gov.au/design-guides/subguides/interviews); [personas](https://www.dto.gov.au/design-guides/subguides/personas); [professional research methods](https://www.dto.gov.au/design-guides/subguides/professional-research-methods); [scenarios](https://www.dto.gov.au/design-guides/subguides/scenarios); [user pathways](https://www.dto.gov.au/design-guides/subguides/user-pathways); [user research](https://www.dto.gov.au/design-guides/guide/user-research); [user stories](https://www.dto.gov.au/design-guides/subguides/user-stories); [workshops](https://www.dto.gov.au/design-guides/subguides/workshops).
+Design guides that will be helpful in meeting this criteria include: [affinity diagramming](https://www.dto.gov.au/standard/design-guides/user-research/affinity-diagramming/);
+ [card sorting](https://www.dto.gov.au/standard/design-guides/user-research/card-sorting); [ethnographic research](https://www.dto.gov.au/standard/design-guides/user-research/ethnographic-research); [high level design](https://www.dto.gov.au/standard/design-guides/user-research/high-level-design); [interviews](https://www.dto.gov.au/standard/design-guides/user-research/interviews); [personas](https://www.dto.gov.au/standard/design-guides/user-research/personas); [professional research methods](https://www.dto.gov.au/standard/design-guides/user-research/professional-research-methods); [scenarios](https://www.dto.gov.au/standard/design-guides/user-research/scenarios); [user pathways](https://www.dto.gov.au/standard/design-guides/user-research/user-pathways); [user research](https://www.dto.gov.au/standard/design-guides/user-research/); [user stories](https://www.dto.gov.au/standard/design-guides/user-research/user-stories); [workshops](https://www.dto.gov.au/standard/design-guides/user-research/workshops).
 
 Potential artefacts that are likely to be produced during Discovery:
 
@@ -42,7 +43,7 @@ The team can meet this criteria by:
 - Establishing the team principles, vision, rituals and practices
 - Demonstrating that they are working an Agile way using tools and techniques that support collaboration and communication
 
-Design guides that will be helpful in meeting this criteria include: [team recruitment](https://www.dto.gov.au/design-guides/subguides/team-recruitment); [the team](https://www.dto.gov.au/design-guides/guide/team); [agile](https://www.dto.gov.au/design-guides/guide/agile);
+Design guides that will be helpful in meeting this criteria include: [team recruitment](https://www.dto.gov.au/standard/design-guides/the-team/team-recruitment/); [the team](https://www.dto.gov.au/standard/design-guides/the-team/); [agile](https://www.dto.gov.au/standard/design-guides/agile/);
 
 Potential artefacts that are likely to be produced during Discovery:
 


### PR DESCRIPTION
There has been some link-rot in several sections of the DSS that haven't
had appropriate referrals setup.
There were also some internal section links that hadn't been setup
correctly
