### PR TITLE
Remove next section recomendations for the last page of guides

### DIFF
--- a/_includes/previous_next.html
+++ b/_includes/previous_next.html
@@ -76,6 +76,16 @@
 
 {% endif %}
 
+{% assign guide_index  = guide.relative_directory  | append: "/index.md" %}
+{% if next_page.path == guide_index %}
+  {% comment %}
+    When we reach the end of the guide, next_page will wrap back to the guide's
+    index. Guides don't necessarially follow a linear sequence, so we don't want
+    to automatically generate any navigation for what to read next.
+  {% endcomment %}
+  {% assign next_page == null %}
+{% endif %}
+
 <aside class="previous-next">
 
   {% if previous_page %}


### PR DESCRIPTION
Guides don't follow a sequential order, so we shouldn't be automatically
recommending what the next section is at the end of a guide.
A better approach is to have a 'further reading' page, like the discovery guide has.
