### PR TITLE
Automatically generate links for section index pages

### DIFF
--- a/_alpha/1-introduction/index.md
+++ b/_alpha/1-introduction/index.md
@@ -2,7 +2,5 @@
 title: '1. Introduction'
 section: 1-introduction
 index: true
+layout: section_index
 ---
-
-- [1.1. What is Alpha?](1-1-what.html)
-- [1.2. A future vision](1-2-future-vision.html)

--- a/_alpha/2-getting-started/index.md
+++ b/_alpha/2-getting-started/index.md
@@ -2,8 +2,5 @@
 title: 2. Getting started
 section: 2-getting-started
 index: true
+layout: section_index
 ---
-
-- [2.1. The team](2-1-the-team.html)
-- [2.2. The kick-off](2-2-the-kick-off.html)
-- [2.3. Ways of working](2-3-ways-of-working.html)

--- a/_alpha/3-building-prototypes/index.md
+++ b/_alpha/3-building-prototypes/index.md
@@ -2,7 +2,5 @@
 title: "3. Building prototypes"
 section: 3-building-prototypes
 index: true
+layout: section_index
 ---
-
-- [3.1. What is a prototype?](3-1-what-is-prototype.html)
-- [3.2. Tools and technology](3-2-tools-technology.html)

--- a/_alpha/4-finishing-alpha/index.md
+++ b/_alpha/4-finishing-alpha/index.md
@@ -2,4 +2,5 @@
 title: "4. Finishing Alpha"
 section: 4-finishing-alpha
 index: true
+layout: section_index
 ---

--- a/_discovery/2-starting-discovery/index.md
+++ b/_discovery/2-starting-discovery/index.md
@@ -2,10 +2,5 @@
 title: "2. Starting discovery"
 section: 2-starting-discovery
 index: true
+layout: section_index
 ---
-
-- [2.1. Before you start](2-1-before-you-start.html)
-- [2.2. The kick-off](2-2-kick-off.html)
-- [2.3. Ways of working](2-3-ways-of-working.html)
-- [2.4. Activities to do](2-4-activities.html)
-- [2.5. Artefacts to produce](2-5-artefacts.html)

--- a/_discovery/3-finishing-discovery/index.md
+++ b/_discovery/3-finishing-discovery/index.md
@@ -2,9 +2,5 @@
 title: '3. Finishing Discovery'
 section: 3-finishing-discovery
 index: true
+layout: section_index
 ---
-
-- [3.1. Identifying the hypotheses to test](3-1-identifying-hypotheses.html)
-- [3.2. Reporting back findings](3-2-reporting-findings.html)
-- [3.3. Assessing against the Digital Service Standard](3-3-digital-service-standard.html)
-- [3.4. Moving into Alpha](3-4-moving-into-alpha.html)

--- a/_layouts/section_index.html
+++ b/_layouts/section_index.html
@@ -1,0 +1,16 @@
+---
+layout: main
+---
+
+{{ content }}
+
+<aside class="section">
+  {% assign guide = site.collections | where:"label",page.collection | first %}
+  {% assign children = guide.docs | where:"section",page.section | where:"index",false %}
+
+  <ul>
+    {% for child in children %}
+    <li><a href="{{ site.baseurl }}{{ child.url }}">{{ child.title }}</a></li>
+    {% endfor %}
+  </ul>
+</aside>


### PR DESCRIPTION
This branch adds a new layout which can dynamically generate the child links for a section index page. 

This also removes hard-coded links from all the existing section indexes in the alpha and discovery guides, moving the pages to use the new layout.

The visual appearance of index pages remains unchanged.
