### PR TITLE
Tweak padding on navigation bar

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -11,6 +11,12 @@ nav {
   }
 }
 
+main.home ul.top-level {
+  @media (min-width: 800px) {
+    padding: 5px 0;
+  }
+}
+
 ul.top-level {
   padding: 0;
 
@@ -26,7 +32,7 @@ ul.top-level {
       color: #fff;
       text-decoration: none;
       font-weight: bold;
-      margin: 10px 0;
+      margin: 0;
       padding: 8px 20px;
       font-size: 18px;
 


### PR DESCRIPTION
This removes margins between the items in the nav menus, and adds additional padding to compensate on the home page.

Before: 
<img width="250" alt="screen shot 2016-03-09 at 1 34 15 pm" src="https://cloud.githubusercontent.com/assets/71922/13623569/ad3334b8-e5fb-11e5-9b59-27695f3e1eeb.png">

After: 
<img width="256" alt="screen shot 2016-03-09 at 1 34 22 pm" src="https://cloud.githubusercontent.com/assets/71922/13623575/b2c8b0c4-e5fb-11e5-87ae-ad0deacf242b.png">
