### PR TITLE
Make guide names bigger on desktop homepage

### DIFF
--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -96,7 +96,10 @@ main.home {
       text-decoration: none;
 
       @media (min-width: 800px) {
-        min-height: 100px;
+        padding: 32px 0;
+        height: 100px;
+        text-align: center;
+        font-size: 23px;
       }
 
       &:hover {


### PR DESCRIPTION
As a quick follow-up to #14, this makes the guide names larger on the desktop/tablet version of the homepage.

<img width="605" alt="screen shot 2016-03-09 at 4 01 04 pm" src="https://cloud.githubusercontent.com/assets/71922/13625856/2a18597c-e610-11e5-9a22-f92ef150d42e.png">
