### PR TITLE
Publish the capability model to the service-handbook

### DIFF
--- a/_includes/section_header.html
+++ b/_includes/section_header.html
@@ -13,7 +13,7 @@
 {% elsif page.collection == 'capability' %}
   <header class="section">
     <h1>
-      <a href="{{ site.baseurl }}/capability">Capabilities</a> <span class="draft">Alpha</span>
+      <a href="{{ site.baseurl }}/capability">Capabilities</a>
     </h1>
   </header>
 {% endif %}

--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -119,6 +119,9 @@ main.home {
     .live a {
       @include guide-background-colour($live-colour);
     }
+    .capability a {
+      @include guide-background-colour($capability-colour);
+    }
   }
 
 }

--- a/index.html
+++ b/index.html
@@ -10,12 +10,19 @@ section: home
 </section>
 
 <ul class="guides-list">
-  <h2>Read guides about:</h2>
+  <h2>Service design and delivery stages:</h2>
   <li class="discovery">
     <a href="{{ site.baseurl }}/discovery">Discovery</a>
   </li>
   <li class="alpha">
     <a href="{{ site.baseurl }}/alpha">Alpha</a>
+  </li>
+</ul>
+
+<ul class="guides-list">
+  <h2>Supporting guides:</h2>
+  <li class="capability">
+    <a href="{{ site.baseurl }}/capability">Capability</a>
   </li>
 </ul>
 


### PR DESCRIPTION
I've added a 'supporting guides' section to the index page, and put the
capability model link there
