### PR TITLE
Add a prototype of a single page view

### DIFF
--- a/_alpha/full.md
+++ b/_alpha/full.md
@@ -1,0 +1,4 @@
+---
+title: Alpha Guide
+layout: full
+---

--- a/_capability/full.md
+++ b/_capability/full.md
@@ -1,0 +1,4 @@
+---
+title: Capability Guide
+layout: full
+---

--- a/_discovery/full.md
+++ b/_discovery/full.md
@@ -1,0 +1,4 @@
+---
+title: Discovery Guide
+layout: full
+---

--- a/_includes/full_table_of_contents.html
+++ b/_includes/full_table_of_contents.html
@@ -1,0 +1,25 @@
+{% assign guide = site.collections | where:"label",page.collection | first %}
+
+<nav>
+  <h1>Contents</h1>
+  <ul class="table-of-contents">
+
+    {% for section in guide.sections %}
+      {% assign sectionfor = forloop %}
+      {% assign index = guide.docs | where:"section",section | where:"index",true | first %}
+
+      <li>
+        <a href="#{{ sectionfor.index }}">{{ index.title }}</a>
+
+        {% assign docs = guide.docs | where:"section",section | where:"index",false %}
+        {% if docs.size > 0 %}
+          <ul>
+            {% for doc in docs %}
+              <li><a href="#{{ sectionfor.index }}-{{ forloop.index }}">{{ doc.title }}</a></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/_layouts/full.html
+++ b/_layouts/full.html
@@ -1,0 +1,28 @@
+---
+layout: base
+---
+
+{% assign guide = site.collections | where:"label",page.collection | first %}
+{% assign children = guide.docs | where:"section",page.section | where:"index",false %}
+
+<article class="full">
+  {% include full_table_of_contents.html %}
+
+  {% for section in guide.sections %}
+    {% assign sectionfor = forloop %}
+
+    <section class="section">
+      {% assign index = guide.docs | where:"section",section | where:"index",true | first %}
+      <h1 id="{{ sectionfor.index }}">{{ index.title }}</h1>
+      {{ index.content }}
+
+      {% assign docs = guide.docs | where:"section",section | where:"index",false %}
+      {% for doc in docs %}
+        <section class="subsection">
+          <h2 id="{{ sectionfor.index }}-{{ forloop.index }}">{{ doc.title }}</h2>
+          {{ doc.content }}
+        </section>
+      {% endfor %}
+    </section>
+  {% endfor %}
+</article>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -8,6 +8,6 @@ layout: base
   {% include previous_next.html %}
 </article>
 
-<nav>
+<nav class="global">
  {% include navigation.html %}
 </nav>

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -76,19 +76,19 @@ main {
   }
 
   &.discovery {
-    header, nav {
+    header, nav.global {
       background: $discovery-colour;
     }
   }
 
   &.alpha {
-    header, nav {
+    header, nav.global {
       background: $alpha-colour;
     }
   }
 
   &.capability {
-    header, nav {
+    header, nav.global {
       background: $capability-colour;
     }
   }
@@ -120,4 +120,31 @@ img.full-width {
 img.half-width {
   display: inline;
   width: 50%;
+}
+
+article.full {
+
+  > section, nav {
+    padding: 20px 0 40px;
+    border-bottom: 1px solid #eee;
+  }
+
+  > section:last-of-type {
+    border-bottom: none;
+  }
+
+  /*
+  Until we rewrite the Markdown to use third-level headings, we will need to
+  hack the <h2>s here so that the first heading has the proper <h2> styling.
+  */
+  > section > section {
+    h2:not(:first-of-type) {
+      font-size: 17px;
+    }
+  }
+
+  nav {
+    padding-top: 0;
+  }
+
 }

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -1,4 +1,4 @@
-nav {
+nav.global {
   background: $primary-colour;
   padding: 10px 0;
 
@@ -81,5 +81,14 @@ ul.guide-content {
         padding: 2px 10px 2px 20px;
       }
     }
+  }
+}
+
+ul.table-of-contents {
+  padding-left: 0;
+
+  li {
+    font-size: 15px;
+    list-style: none;
   }
 }

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -127,3 +127,7 @@ blockquote {
   background: #e4e4e4;
   margin-left:2em;
 }
+
+section.subsection h3 {
+  font-size: 100%;
+}


### PR DESCRIPTION
This adds a prototype of an alternative view of a handbook, where all content is presented in a single page.

For the present time, this will be used only for testing alongside the existing primary view. It will not be offered as an option to users reading the guides.
