### PR TITLE
Setup the in-flight assessments manual

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,16 @@ collections:
       - 8-integration
       - 9-deployment
 
+  inflight:
+    output: true
+    name: In-flight assessments
+    sections:
+      - 1-in-flight-assessments
+      - 2-check-ins
+      - 3-assessment-reviews
+      - 4-delivery-stages
+      - 5-tools
+
 defaults:
   - scope:
       path: ""

--- a/_includes/section_header.html
+++ b/_includes/section_header.html
@@ -16,4 +16,10 @@
       <a href="{{ site.baseurl }}/capability">Capabilities</a>
     </h1>
   </header>
+{% elsif page.collection == 'inflight' %}
+  <header class="section">
+    <h1>
+      <a href="{{ site.baseurl }}/inflight">In-flight assessments</a>
+    </h1>
+  </header>
 {% endif %}

--- a/_inflight/1-in-flight-assessments/index.md
+++ b/_inflight/1-in-flight-assessments/index.md
@@ -1,5 +1,6 @@
 ---
 title: In-flight assessments
+section: 1-in-flight-assessments
 index: true
 ---
 

--- a/_inflight/2-check-ins/index.md
+++ b/_inflight/2-check-ins/index.md
@@ -1,5 +1,6 @@
 ---
 title: Check-ins
+section: 2-check-ins
 index: true
 ---
 

--- a/_inflight/3-assessment-reviews/index.md
+++ b/_inflight/3-assessment-reviews/index.md
@@ -1,5 +1,6 @@
 ---
 title: Assessment reviews
+section: 3-assessment-reviews
 index: true
 ---
 

--- a/_inflight/4-delivery-stages/index.md
+++ b/_inflight/4-delivery-stages/index.md
@@ -1,5 +1,6 @@
 ---
 title: The delivery stages
+section: 4-delivery-stages
 index: true
 ---
 

--- a/_inflight/5-tools/index.md
+++ b/_inflight/5-tools/index.md
@@ -1,5 +1,6 @@
 ---
 title: Tools
+section: 5-tools
 index: true
 ---
 

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -75,6 +75,10 @@ main {
     }
   }
 
+  header, nav.global {
+    background: $primary-colour;
+  }
+
   &.discovery {
     header, nav.global {
       background: $discovery-colour;


### PR DESCRIPTION
This builds on the work done in #23 to configure the in-flight assessments manual.

This pull request:
- Sets up the header and navigation bar for the in-flight assessments manual
- Adds section metadata to each piece of content
- Defaults to using the primary colour for the header and navigation bar when there isn't a custom one defined.
